### PR TITLE
name is missing in metadata.rb file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
 # Original source: https://github.com/scalarium/cookbooks/tree/master/ebs
 # Updated by Jonathan Rudenberg (jonathan@titanous.com)
 
+name "ebs"
 maintainer "Jonathan Rudenberg"
 maintainer_email "jonathan@titanous.com"
 description "Mounts attached EBS volumes"


### PR DESCRIPTION
Since the `name` was not in this metadata.rb file, `berkshelf` errors out saying:
 `Cookbook 'ebs' not found in any of the default locations`.
