### PR TITLE
Default to /dev/xvdf if no devices found.

### DIFF
--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -1,7 +1,10 @@
 node[:ebs][:volumes].each do |mount_point, options|
   if !options[:device] && options[:size]
     credentials = Chef::EncryptedDataBagItem.load(node[:ebs][:creds][:databag], node[:ebs][:creds][:item])
-    devid = Dir.glob('/dev/xvd?').sort.last[-1,1].succ
+
+    devices = Dir.glob('/dev/xvd?')
+    devices = ['/dev/xvdf'] if devices.empty?
+    devid = devices.sort.last[-1,1].succ
     device = "/dev/sd#{devid}"
 
     vol = aws_ebs_volume device do


### PR DESCRIPTION
Just a bugfix for when there are no other attached volumes.
