### PR TITLE
Add 'nobootwait' to mount options.

### DIFF
--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -37,7 +37,7 @@ node[:ebs][:volumes].each do |mount_point, options|
   mount mount_point do
     fstype options[:fstype]
     device options[:device]
-    options 'noatime'
+    options 'noatime,nobootwait'
     action [:mount, :enable]
   end
 end


### PR DESCRIPTION
We don't want the instance to fail booting just because an EBS volume
is inaccessible.
