### PR TITLE
Fix attribute name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Create a 10GB volume, format it with XFS, and mount it on `/data`.
 
 ## Credentials
 
-Expects a `credentials` databag with an `aws` item that contains `access_key_id` and `secret_access_key`.
+Expects a `credentials` databag with an `aws` item that contains `aws_access_key_id` and `aws_secret_access_key`.
 
 You can override the databag and item names with `node[:ebs][:creds][:databag]`, and `node[:ebs][:creds][:item]`, but the key names are static.
 


### PR DESCRIPTION
Updated the readme to reflect the attribute change from `access_key_id` to `aws_access_key_id` and `secret_access_key` to `aws_secret_access_key`
