### PR TITLE
Add support for provisioned iops volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ filesystems and RAID arrays on them.
 
 Add `recipe[ebs]` to your run list, and configure these attributes:
 
-Create a RAID 10 across four 10GB volumes, make it an lvm logical volume, format it with XFS, and mount it on
+Create a RAID 10 across four 10GB volumes each with 2000 provisioned iops, make it an lvm logical volume, format it with XFS, and mount it on
 `/data`.
 
 ```ruby
@@ -20,6 +20,7 @@ Create a RAID 10 across four 10GB volumes, make it an lvm logical volume, format
       '/dev/md0' => {
         :num_disks => 4,
         :disk_size => 10,
+        :piops => 2000,
         :raid_level => 10,
         :fstype => 'xfs',
         :mount_point => '/data',
@@ -59,7 +60,7 @@ Create a RAID 10 across the volumes specified in the `persistent_volumes` array,
 
 ### EBS Volume Creation
 
-Create a 10GB volume, format it with XFS, and mount it on `/data`.
+Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount it on `/data`.
 
 ```ruby
 {
@@ -67,6 +68,7 @@ Create a 10GB volume, format it with XFS, and mount it on `/data`.
     :volumes => {
       '/data' => {
         :size => 10,
+        :piops => 1000,
         :fstype => 'xfs'
       }
     }

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,4 @@ recipe "ebs::volumes", "Mounts attached EBS volumes"
 recipe "ebs::raids", "Mounts attached EBS RAIDs"
 recipe "ebs::persistent", "Mounts volumes defined in attributes"
 
-depends 'aws'
+depends 'aws', '>= 0.101.0'

--- a/recipes/raids.rb
+++ b/recipes/raids.rb
@@ -31,6 +31,8 @@ node[:ebs][:raids].each do |device, options|
         size options[:disk_size]
         device mount
         availability_zone node[:ec2][:placement_availability_zone]
+        volume_type options[:piops] ? 'io1' : 'standard'
+        piops options[:piops]
         action :nothing
       end
       vol.run_action(:create)

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -22,6 +22,8 @@ node[:ebs][:volumes].each do |mount_point, options|
       size options[:size]
       device device
       availability_zone node[:ec2][:placement_availability_zone]
+      volume_type options[:piops] ? 'io1' : 'standard'
+      piops options[:piops]
       action :nothing
     end
     vol.run_action(:create)


### PR DESCRIPTION
This adds support for creating provisioned iops volumes.  Tested with plain vanilla volumes, not tested with RAID.

Note that provisioned IOPS volumes must have a minimum of 100 IOPS provisioned, and be at a maximum ratio of 10:1 PIOPS to volume size.  Neither of these limits are enforced in the updated cookbook.
