### PR TITLE
Configurable mount options and fix nobootwait on amazon linux 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Create a RAID 10 across the volumes specified in the `persistent_volumes` array,
 
 ### EBS Volume Creation
 
-Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount it on `/data`.
+Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount it on `/data` with `noatime` as an option.
 
 ```ruby
 {
@@ -69,12 +69,15 @@ Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount i
       '/data' => {
         :size => 10,
         :piops => 1000,
-        :fstype => 'xfs'
+        :fstype => 'xfs',
+        :mount_options => 'noatime'
       }
     }
   }
 }
 ```
+
+`mount_options` are optional and will default to `noatime,nobootwait` on all platforms except Amazon linux, where they will default to `noatime`.
 
 ## Credentials
 

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -1,8 +1,8 @@
 node[:ebs][:volumes].each do |mount_point, options|
-  
+
   # skip volumes that already exist
   next if File.read('/etc/mtab').split("\n").any?{|line| line.match(" #{mount_point} ")}
-  
+
   # create ebs volume
   if !options[:device] && options[:size]
     if node[:ebs][:creds][:encrypted]
@@ -52,10 +52,18 @@ node[:ebs][:volumes].each do |mount_point, options|
     mode 0755
   end
 
+  mount_options = if !options[:mount_options].to_a.empty?
+                    options[:mount_options].join(",")
+                  elsif node[:platform] == 'amazon'
+                    'noatime'
+                  else
+                    'noatime,nobootwait'
+                  end
+
   mount mount_point do
     fstype options[:fstype]
     device device
-    options 'noatime,nobootwait'
+    options mount_options
     action [:mount, :enable]
   end
 


### PR DESCRIPTION
nobootwait doesn't seem to be supported on Amazon linux.  Also making mount options configurable.

Tested w/ plain volumes; not tested with RAID.
