### PR TITLE
Skip KVM device translation if no devices found.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,7 @@ default[:ebs][:md_read_ahead] = '65536' # 64k
 default[:ebs][:initrd_md5] = ''
 
 
-if BlockDevice.on_kvm?
+if BlockDevice.on_kvm? && ebs[:devices]
   Chef::Log.info("Running on QEMU/KVM: Need to translate device names as KVM allocates them regardless of the given device ID")
   ebs_devices = {}
 


### PR DESCRIPTION
KVM guests error out if `ebs` exists somewhere in the dependency chain, since ´ebs[:devices]` is empty.

<!---
@huboard:{"order":18.0}
-->
