### PR TITLE
Fix bug on options[:mount_options] and added pass option to volume creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount i
 
 `mount_options` are optional and will default to `noatime,nobootwait` on all platforms except Amazon linux, where they will default to `noatime`.
 
+`pass` The pass number used by the file system check (fsck) command while creating a file systems table (fstab) entry. Optional property (Default: 2).
+
 ## Credentials
 
 Expects a `credentials` databag with an `aws` item that contains `aws_access_key_id` and `aws_secret_access_key`.

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -58,6 +58,9 @@ node[:ebs][:volumes].each do |mount_point, options|
     else
         options options[:mount_options]
     end
+    if options[:pass]
+        pass options[:pass]
+    end
     action [:mount, :enable]
   end
 


### PR DESCRIPTION
- using options[:mount_options] on volume creation if that option is provided
- Added "pass" option on volume creation. The pass number used by the file system check (fsck) command while creating a file systems table (fstab) entry. Optional property (Default: 2)
