### PR TITLE
fix chef syntax problem in raids recipe

### DIFF
--- a/recipes/raids.rb
+++ b/recipes/raids.rb
@@ -54,10 +54,12 @@ node[:ebs][:raids].each do |raid_device, options|
     action :create
   end
 
-  Chef::Log.info("Waiting for individual disks of RAID #{options[:mount_point]}")
-  options[:disks].each do |disk_device|
-    ruby_block "wait_for #{disk_device}" do
-      BlockDevice::wait_for(disk_device)
+  ruby_block "wait for devices" do
+    block do
+      Chef::Log.info("Waiting for individual disks of RAID #{options[:mount_point]}")
+      options[:disks].each do |disk_device|
+        BlockDevice::wait_for(disk_device)
+      end
     end
   end
 


### PR DESCRIPTION
This should fix the raids recipe and prevent chef from looping during compile. This was taken from #17 and should fix #21. The `ruby_block` resource needs a block param which should contain the ruby code. The current resource is missing the block and so the code is still executed during the compile phase.