### PR TITLE
Encrypted Volumes, GP2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Create a RAID 10 across the volumes specified in the `persistent_volumes` array,
 
 ### EBS Volume Creation
 
-Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount it on `/data` with `noatime` as an option.
+Create a 10GB EBS General Purpose SSD volume, format it with XFS, and mount it on `/data` with `noatime` as an option.
 
 ```ruby
 {
@@ -68,7 +68,7 @@ Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount i
     :volumes => {
       '/data' => {
         :size => 10,
-        :piops => 1000,
+        :volume_type => 'gp2',
         :fstype => 'xfs',
         :mount_options => 'noatime'
       }

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Create a 10GB volume with 1000 provisioned iops, format it with XFS, and mount i
 
 `mount_options` are optional and will default to `noatime,nobootwait` on all platforms except Amazon linux, where they will default to `noatime`.
 
+## Volume Encryption
+
+You can provide `encrypted: true` for an encrypted volume.
+
 ## Credentials
 
 Expects a `credentials` databag with an `aws` item that contains `aws_access_key_id` and `aws_secret_access_key`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,8 +8,8 @@ default[:ebs][:raids] = {}
 default[:ebs][:mdadm_chunk_size] = '256'
 default[:ebs][:md_read_ahead] = '65536' # 64k
 default[:ebs][:initrd_md5] = ''
+default[:ebs][:volume_type] = 'standard' # or gp2 for SSD disks by default (more expensive)
 default[:ebs][:encrypted] = false
-
 
 if BlockDevice.on_kvm? && ebs[:devices]
   Chef::Log.info("Running on QEMU/KVM: Need to translate device names as KVM allocates them regardless of the given device ID")

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@ default[:ebs][:raids] = {}
 default[:ebs][:mdadm_chunk_size] = '256'
 default[:ebs][:md_read_ahead] = '65536' # 64k
 default[:ebs][:initrd_md5] = ''
+default[:ebs][:encrypted] = false
 
 
 if BlockDevice.on_kvm? && ebs[:devices]

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,5 @@ recipe "ebs::volumes", "Mounts attached EBS volumes"
 recipe "ebs::raids", "Mounts attached EBS RAIDs"
 recipe "ebs::persistent", "Mounts volumes defined in attributes"
 
-depends 'aws', '>= 0.101.0'
+depends 'aws', '~> 2.7.0'
 depends 'delayed_evaluator'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ if BlockDevice.on_kvm?
     owner "root"
     mode 0644
   end
-  
+
   execute "Reload udev rules" do
     command "udevadm control --reload-rules"
   end

--- a/recipes/raids.rb
+++ b/recipes/raids.rb
@@ -34,6 +34,7 @@ node[:ebs][:raids].each do |device, options|
         device mount
         availability_zone node[:ec2][:placement_availability_zone]
         volume_type options[:piops] ? 'io1' : 'standard'
+        encrypted options[:encrypted] || node[:ebs][:encrypted]
         piops options[:piops]
         action [ :create, :attach ]
       end

--- a/recipes/raids.rb
+++ b/recipes/raids.rb
@@ -27,13 +27,21 @@ node[:ebs][:raids].each do |device, options|
       disks << mount = "/dev/sd#{next_mount}"
       next_mount = next_mount.succ
 
+      volume_type = if options[:piops]
+                      'io1'
+                    elsif options[:volume_type]
+                      options[:volume_type]
+                    else
+                      node[:ebs][:volume_type]
+                    end
+
       aws_ebs_volume mount do
         aws_access_key credentials[node.ebs.creds.aki]
         aws_secret_access_key credentials[node.ebs.creds.sak]
         size options[:disk_size]
         device mount
         availability_zone node[:ec2][:placement_availability_zone]
-        volume_type options[:piops] ? 'io1' : 'standard'
+        volume_type volume_type
         encrypted options[:encrypted] || node[:ebs][:encrypted]
         piops options[:piops]
         action [ :create, :attach ]

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -23,6 +23,7 @@ node[:ebs][:volumes].each do |mount_point, options|
       device device
       availability_zone node[:ec2][:placement_availability_zone]
       volume_type options[:piops] ? 'io1' : 'standard'
+      encrypted options[:encrypted] || node[:ebs][:encrypted]
       piops options[:piops]
       action :nothing
     end

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -16,13 +16,21 @@ node[:ebs][:volumes].each do |mount_point, options|
     devid = devices.sort.last[-1,1].succ
     device = "/dev/sd#{devid}"
 
+    volume_type = if options[:piops]
+                    'io1'
+                  elsif options[:volume_type]
+                    options[:volume_type]
+                  else
+                    node[:ebs][:volume_type]
+                  end
+
     vol = aws_ebs_volume device do
       aws_access_key credentials[node.ebs.creds.aki]
       aws_secret_access_key credentials[node.ebs.creds.sak]
       size options[:size]
       device device
       availability_zone node[:ec2][:placement_availability_zone]
-      volume_type options[:piops] ? 'io1' : 'standard'
+      volume_type volume_type
       encrypted options[:encrypted] || node[:ebs][:encrypted]
       piops options[:piops]
       action :nothing


### PR DESCRIPTION
Adds support for encrypted volumes and GP2 volumes (addresses #24).

Encrypted volumes requires AWS cookbook 2.7.0.