### PR TITLE
Fixed issue where mount options weren't used for mounting volumes

### DIFF
--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -52,10 +52,18 @@ node[:ebs][:volumes].each do |mount_point, options|
     mode 0755
   end
 
+  case node[:platform]
+  when 'amazon'
+    default_mount_options = 'noatime'  
+  else
+    default_mount_options = 'noatime,nobootwait'
+  end
+  mount_options = options[:mount_options] || default_mount_options
+
   mount mount_point do
     fstype options[:fstype]
     device device
-    options 'noatime,nobootwait'
+    options mount_options
     action [:mount, :enable]
   end
 


### PR DESCRIPTION
README stated that mount_options were supported and defaulted to separate options between Amazon Linux and all others.

Updated the recipe to reflect the documentation. Ran into this while trying to mount an XFS EBS volume on a Centos7 box.