### PR TITLE
Skip some devices

### DIFF
--- a/recipes/persistent.rb
+++ b/recipes/persistent.rb
@@ -13,6 +13,7 @@ if devices.empty?
   next_mount = "a"
 else
   next_mount = devices.map{ |x| x[0,9] }.uniq.sort.last[-1,1].succ
+  next_mount = 'f' unless next_mount >= 'f'
 end
 next_mount.gsub!("xvd","sd")
 

--- a/recipes/persistent.rb
+++ b/recipes/persistent.rb
@@ -10,7 +10,7 @@ aws = data_bag_item(node['ebs']['creds']['databag'], node['ebs']['creds']['item'
 
 devices = Dir.glob('/dev/xvd*')
 if devices.empty?
-  next_mount = "a"
+  next_mount = "f"
 else
   next_mount = devices.map{ |x| x[0,9] }.uniq.sort.last[-1,1].succ
   next_mount = 'f' unless next_mount >= 'f'

--- a/recipes/raids.rb
+++ b/recipes/raids.rb
@@ -22,6 +22,7 @@ node[:ebs][:raids].each do |device, options|
       next_mount = "a"
     else
       next_mount = devices.map{ |x| x[0,9] }.uniq.sort.last[-1,1].succ
+      next_mount = 'f' unless next_mount >= 'f'
     end
     1.upto(options[:num_disks].to_i) do |i|
       disks << mount = "/dev/sd#{next_mount}"

--- a/recipes/raids.rb
+++ b/recipes/raids.rb
@@ -19,7 +19,7 @@ node[:ebs][:raids].each do |device, options|
   if !options[:disks] && options[:num_disks]
     devices = Dir.glob('/dev/xvd*')
     if devices.empty?
-      next_mount = "a"
+      next_mount = "f"
     else
       next_mount = devices.map{ |x| x[0,9] }.uniq.sort.last[-1,1].succ
       next_mount = 'f' unless next_mount >= 'f'

--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -14,6 +14,7 @@ node[:ebs][:volumes].each do |mount_point, options|
     devices = Dir.glob('/dev/xvd?')
     devices = ['/dev/xvdf'] if devices.empty?
     devid = devices.sort.last[-1,1].succ
+    devid = 'f' unless devid >= 'f'
     device = "/dev/sd#{devid}"
 
     vol = aws_ebs_volume device do


### PR DESCRIPTION
When using some instance types, this cookbook can try to attach volumes to "taboo" devices like `sdc`/`xvdc`. Skipping the first few devices and setting the minimum to `f` should avoid a lot of troubles.
