### PR TITLE
Let's use nofail.

### DIFF
--- a/recipes/volumes.rb
+++ b/recipes/volumes.rb
@@ -53,10 +53,17 @@ node[:ebs][:volumes].each do |mount_point, options|
     mode 0755
   end
 
+  fstab_options = value_for_platform(
+    'default' => 'noatime,nobootwait',
+    'ubuntu' => {
+      '>= 16.04' => 'noatime,nofail'
+    }
+  )
+
   mount mount_point do
     fstype options[:fstype]
     device device
-    options 'noatime,nobootwait'
+    options fstab_options
     action [:mount, :enable]
   end
 


### PR DESCRIPTION
`nobootwait` is no more; the approach of listing platforms and versions is not scalable, I know, but this is just a band aid, not a long term solution.

R: @kvs.